### PR TITLE
use ALWAYSASSERT for both of the (above and below) errors

### DIFF
--- a/src/polyclipper2dImpl.hh
+++ b/src/polyclipper2dImpl.hh
@@ -281,7 +281,7 @@ void clipPolygon(std::vector<Vertex2d<VA>>& polygon,
           above = false;
         }
       }
-      PCASSERT2(not (above and below), internal::dumpSerializedState(initial_state));
+      PCALWAYSASSERT(not (above and below));
     }
 
     // Did we get a simple case?

--- a/src/polyclipper3dImpl.hh
+++ b/src/polyclipper3dImpl.hh
@@ -311,7 +311,7 @@ void clipPolyhedron(std::vector<Vertex3d<VA>>& polyhedron,
           above = false;
         }
       }
-      PCASSERT2(not (above and below), internal::dumpSerializedState(initial_state));
+      PCALWAYSASSERT(not (above and below));
     }
 
     // Did we get a simple case?

--- a/src/polyclipper_utilities.hh
+++ b/src/polyclipper_utilities.hh
@@ -53,7 +53,7 @@ public:
 #   define PCALWAYSASSERT2(condition, message)                                 \
     do {                                                                       \
         if (! (condition)) {                                                   \
-            throw PolyClipperError();                                          \
+            throw PolyClipperError(std::string());                             \
         }                                                                      \
     } while (false)
 #endif

--- a/src/polyclipper_utilities.hh
+++ b/src/polyclipper_utilities.hh
@@ -53,7 +53,7 @@ public:
 #   define PCALWAYSASSERT2(condition, message)                                 \
     do {                                                                       \
         if (! (condition)) {                                                   \
-            throw PolyClipperError(s.str());                                   \
+            throw PolyClipperError());                                         \
         }                                                                      \
     } while (false)
 #endif

--- a/src/polyclipper_utilities.hh
+++ b/src/polyclipper_utilities.hh
@@ -53,10 +53,6 @@ public:
 #   define PCALWAYSASSERT2(condition, message)                                 \
     do {                                                                       \
         if (! (condition)) {                                                   \
-            std::ostringstream s;                                              \
-            s << "PolyCliper ERROR: Assertion `" #condition "` failed in "     \
-              << __FILE__ << " line " << __LINE__ << ": \n" << message << "\n";\
-            std::cerr << s.str();                                              \
             throw PolyClipperError(s.str());                                   \
         }                                                                      \
     } while (false)

--- a/src/polyclipper_utilities.hh
+++ b/src/polyclipper_utilities.hh
@@ -53,7 +53,7 @@ public:
 #   define PCALWAYSASSERT2(condition, message)                                 \
     do {                                                                       \
         if (! (condition)) {                                                   \
-            throw PolyClipperError());                                         \
+            throw PolyClipperError();                                          \
         }                                                                      \
     } while (false)
 #endif


### PR DESCRIPTION
The (above and below) error condition is checked in a couple of spots--one for a bounding box check, and another where the individual vertices are compared with the clip plane. This patch changes the assert to PCALWAYSASSERT in both cases. Also, in a non-debug build, we probably don't want the serialized state dumps to be written. 