### PR TITLE
Fix bug where default PolyClipper install directory is not set properly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ endif()
 # Install
 #-------------------------------------------------------------------------------
 if(NOT POLYCLIPPER_INSTALL_DIR)
-  set(POLYCLIPPER_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR})
+  set(POLYCLIPPER_INSTALL_DIR include)
 endif()
 message("-- PolyClipper install path: ${CMAKE_INSTALL_PREFIX}/${POLYCLIPPER_INSTALL_DIR}")
 

--- a/docs/building.rst
+++ b/docs/building.rst
@@ -75,7 +75,7 @@ POLYCLIPPER_ENABLE_CXXONLY
   Only install the C++ headers, also sets ``POLYCLIPPER_MODULE_GEN`` to ``OFF`` -- defaults to ``OFF``.
 
 POLYCLIPPER_INSTALL_DIR
-  Specify where the header files will be installed -- defaults to ``CMAKE_INSTALL_INCLUDEDIR``.
+  Specify where the header files will be installed -- defaults to ``include``.
 
 -------
 Testing


### PR DESCRIPTION
`POLYCLIPPER_INSTALL_DIR` was defaulting to a blank variable.